### PR TITLE
New cli command sign-json

### DIFF
--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/Cli.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/Cli.scala
@@ -65,6 +65,7 @@ case class Config(command: Command,
                   serverCertPath: Option[Path] = None,
                   delegatedPaths: List[DelegatedPathPattern] = List.empty,
                   keyPaths: List[Path] = List.empty,
+                  pubKeyPath: Option[Path] = None,
                   force: Boolean = false,
                   reposerverUrl: Option[URI] = None,
                   verbose: Boolean = false,
@@ -162,6 +163,22 @@ object Cli extends App with VersionInfo {
     }
 
     version("version").text("Prints the current binary version.")
+
+    note(" " + sys.props("line.separator"))
+
+    cmd("sign-json")
+      .toCommand(SignUserJson)
+      .text("Signs valid user provided json with a specified key")
+      .children(
+        opt[Path]("priv-key").abbr("k")
+          .text("The path to the private key to use to sign json")
+          .action { (arg, c) => c.copy(keyPaths = arg :: c.keyPaths) },
+        opt[Path]("pub-key").abbr("p")
+          .text("The path to the public key to use to sign json")
+          .toConfigOptionParam('pubKeyPath),
+        opt[Path]('i', "input").toConfigOptionParam('inputPath)
+          .text("path to input json")
+      )
 
     note(" " + sys.props("line.separator"))
 

--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/Commands.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/Commands.scala
@@ -29,6 +29,7 @@ object Commands {
   case object CreateDelegation extends Command
   case object SignDelegation extends Command
   case object GenUserKey extends Command
+  case object SignUserJson extends Command
   case object IdUserKey extends Command
   case object PushDelegation extends Command
   case object PullDelegation extends Command


### PR DESCRIPTION
Signs a json blob with the provided keys.

For example:

```
$ echo '{"target-name": "target01"}' > blob.json

$ garage-sign user-keys gen --key-name mykey
Saved keys to tuf/user-keys/{mykey.sec, mykey.pub}

$ garage-sign sign-json -k tuf/user-keys/mykey.sec -p
tuf/user-keys/mykey.pub -i blob.json
{
  "signatures" : [
    {
      "keyid" : "111c13990d21bc57ee7d4ea034e6b13f47c4746a5f89e2a6e91223479067f8ea",
      "method" : "ed25519",
      "sig" : "txC/qzquXr2wurGdbO7mi9TphFS924BuFYgKYwvJdkvlw+RbHD+iAW5nCx3YA4y5HhhPrEhOUm4tik58zU5vAQ=="
    }
  ],
  "signed" : {
    "target-name" : "target01"
  }
}

```