### PR TITLE
Use net.i2p.i2p instead of crypto

### DIFF
--- a/libtuf/build.sbt
+++ b/libtuf/build.sbt
@@ -4,7 +4,7 @@ libraryDependencies ++= {
   Seq(
     "org.bouncycastle" % "bcprov-jdk15on" % bouncyCastleV,
     "org.bouncycastle" % "bcpkix-jdk15on" % bouncyCastleV,
-    "net.i2p.crypto" % "eddsa" % "0.3.0",
+    "net.i2p" % "i2p" % "1.8.0",
     "com.softwaremill.sttp.client" %% "core" % "2.3.0",
     "com.softwaremill.sttp.client" %% "slf4j-backend" % "2.3.0",
     "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % "2.3.0",


### PR DESCRIPTION
crypto has not been updated in a while and was causing some flaky
tests, presumably because it was compiled with an older version of
java which makes the binary is not binary compatible with jvm17

The errors looked like:

```
Caused by: java.lang.IllegalAccessError: class net.i2p.crypto.eddsa.EdDSAEngine (in unnamed module @0x3e07d849) cannot access class sun.security.x509.X509Key (in module java.base) because module java.base does not export sun.security.x509 to unnamed module @0x3e07d849
```