### PR TITLE
Support adding external ed25519 signatures

### DIFF
--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/TufRepo.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/TufRepo.scala
@@ -30,7 +30,6 @@ import com.advancedtelematic.libtuf.data.ClientDataType.{
 import com.advancedtelematic.libtuf.data.RootManipulationOps._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
-import com.advancedtelematic.libtuf.data.TufDataType.SignatureMethod.RSASSA_PSS_SHA256
 import com.advancedtelematic.libtuf.data.TufDataType.{
   ClientSignature,
   KeyId,
@@ -295,8 +294,8 @@ abstract class TufRepo[S <: TufServerClient](val repoPath: Path)(implicit ec: Ex
     signatures
       .map { case (key, sig) => (keyStorage.readPublicKey(key), sig) }
       .sequence
-      .map { sigs => // TODO: RSASSA_PSS_SHA256 hard coded here. This is not good enough.
-        sigs.transform { case (key, sig) => ClientSignature(key.id, RSASSA_PSS_SHA256, sig) }
+      .map { sigs =>
+        sigs.transform { case (key, sig) => ClientSignature(key.id, key.keytype.crypto.signatureMethod, sig) }
       }
 
   private def invalidSignature[T: Encoder](unsignedRole: T,

--- a/cli/src/test/scala/com/advancedtelematic/tuf/cli/TufRepoSpec.scala
+++ b/cli/src/test/scala/com/advancedtelematic/tuf/cli/TufRepoSpec.scala
@@ -305,8 +305,8 @@ class TufRepoSpec extends CliSpec with KeyTypeSpecSupport with TryValues with Ei
     val repo = initRepo[RepoServerRepo](RsaKeyType)
     val targetsKey1Name = KeyName("somekey")
     val targetsKey2Name = KeyName("someotherkey")
-    val targetsKey1Pair = repo.genKeys(targetsKey1Name, KeyType.default).success.value
-    val targetsKey2Pair = repo.genKeys(targetsKey2Name, KeyType.default).success.value
+    val targetsKey1Pair = repo.genKeys(targetsKey1Name, RsaKeyType).success.value
+    val targetsKey2Pair = repo.genKeys(targetsKey2Name, RsaKeyType).success.value
 
     val wrongSignature = Refined.unsafeApply[String, ValidSignature](
       Base64.getEncoder.encodeToString("wrong signature".getBytes)


### PR DESCRIPTION
RSASSA_PSS_SHA256 was hard-coded as the signature method when adding an external signature. This PR selects the signature method based on the key type; this should be fine unless/until we start supporting more than one signature method per key type.